### PR TITLE
Remove enumerating the list when not required

### DIFF
--- a/src/Zoombraco/Helpers/ContentHelper.cs
+++ b/src/Zoombraco/Helpers/ContentHelper.cs
@@ -393,10 +393,10 @@ namespace Zoombraco.Helpers
             // Filter the collection if necessary by our specific type.
             if (!this.IsInheritableType(returnType))
             {
-                IEnumerable<IPublishedContent> publishedContent =
-                    contentList.Where(c => c.DocumentTypeAlias.InvariantEquals(returnType.Name)).ToArray();
+                contentList =
+                    contentList.Where(c => c.DocumentTypeAlias.InvariantEquals(returnType.Name));
 
-                foreach (IPublishedContent content in publishedContent)
+                foreach (IPublishedContent content in contentList)
                 {
                     Type type = this.GetRegisteredType(content.DocumentTypeAlias);
 

--- a/src/Zoombraco/Helpers/ContentHelper.cs
+++ b/src/Zoombraco/Helpers/ContentHelper.cs
@@ -383,9 +383,7 @@ namespace Zoombraco.Helpers
         /// </returns>
         private IEnumerable<T> FilterAndParseCollection<T>(IEnumerable<IPublishedContent> contentList)
         {
-            // Prevent multiple enumeration.
-            IEnumerable<IPublishedContent> publishedContent = contentList as IPublishedContent[] ?? contentList.ToArray();
-            if (!publishedContent.Any())
+            if (!contentList.Any())
             {
                 yield break;
             }
@@ -395,7 +393,8 @@ namespace Zoombraco.Helpers
             // Filter the collection if necessary by our specific type.
             if (!this.IsInheritableType(returnType))
             {
-                publishedContent = publishedContent.Where(c => c.DocumentTypeAlias.InvariantEquals(returnType.Name));
+                IEnumerable<IPublishedContent> publishedContent =
+                    contentList.Where(c => c.DocumentTypeAlias.InvariantEquals(returnType.Name)).ToArray();
 
                 foreach (IPublishedContent content in publishedContent)
                 {
@@ -414,7 +413,7 @@ namespace Zoombraco.Helpers
             else
             {
                 // If we are passed an interface or a base type then we want to return all types that implement that interface or type.
-                foreach (IPublishedContent content in publishedContent)
+                foreach (IPublishedContent content in contentList)
                 {
                     Type type = this.GetRegisteredType(content.DocumentTypeAlias);
 


### PR DESCRIPTION
The cast to Array evaluates the whole list even in the case where we apply a Where condition in the IsInheritableType scenario. Don't think there is a need to break when empty list as that will happen automatically.